### PR TITLE
set input type file width to 100% if in input-group

### DIFF
--- a/public/app.css
+++ b/public/app.css
@@ -205,6 +205,24 @@ div.input-group-prepend{
 .custom-control{
   display: flex;
 }
-.input-group input[type=file] {
-    width: 100%;
+
+@media screen and (max-width: 561px) {
+    .input-group {
+        flex-direction: column;
+    }
+
+    .input-group-text, .input-group input:not([type="checkbox"]), .input-group select {
+        width: 100%;
+    }
+
+    .input-group-text {
+        border-right: 1px solid #ced4da;
+        border-bottom: none;
+        border-radius: .25rem .25rem 0 0;
+    }
+
+    .input-group input, .input-group select {
+        border-top: none;
+        border-radius: 0 0 .25rem .25rem;
+    }
 }

--- a/public/app.css
+++ b/public/app.css
@@ -205,3 +205,6 @@ div.input-group-prepend{
 .custom-control{
   display: flex;
 }
+.input-group input[type=file] {
+    width: 100%;
+}


### PR DESCRIPTION
Hi, regarding issue #8 the only way I found without completely changing the html markup was to set the input type file width to 100% if it's inside an input-group. 

This works fine on my test devices:

![image](https://user-images.githubusercontent.com/5655764/95107204-e1ef0380-0739-11eb-9525-c454110b03fe.png)
